### PR TITLE
Improvements to printMetrics

### DIFF
--- a/collectors/stats_collector.go
+++ b/collectors/stats_collector.go
@@ -123,6 +123,7 @@ func (c *StatCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.validDesc
 	ch <- c.expiredDesc
 	ch <- c.countDesc
+	ch <- c.modTimeDesc
 
 	c.scrapesTotalMetric.Describe(ch)
 	c.scrapeErrorsTotalMetric.Describe(ch)

--- a/collectors/stats_collector.go
+++ b/collectors/stats_collector.go
@@ -29,7 +29,7 @@ func NewStatsCollector(namespace string, info *dhcpdleasesreader.DhcpdInfo, mux 
 	)
 
 	expiredDesc := prometheus.NewDesc(prometheus.BuildFQName(namespace, "stats", "expired"),
-		"The number of leases in dhcpd.leases that have xpired",
+		"The number of leases in dhcpd.leases that have expired",
 		nil, nil,
 	)
 


### PR DESCRIPTION
Three improvements to `--printMetrics`:

1. Add missing `filetime` metric to the list.
2. Avoid race condition in the `eatOutput` goroutine which caused metrics to interleave with the section titles or be missing entirely.
3. Don't attempt to read the `--dhcpd.leases` file if only describing the metrics.

Notice where `dhcpd_leases_stats_last_scrape_duration_seconds` appeared. And `dhcpd_leases_active_last_scrape_duration_seconds` was missing entirely:
```
# ./dhcpd_leases_exporter --printMetrics
Stats
  dhcpd_leases_stats_valid - The number of leases in dhcpd.leases that have not yet expired
  dhcpd_leases_stats_expired - The number of leases in dhcpd.leases that have xpired
  dhcpd_leases_stats_count - The number of leases in dhcpd.leases
  dhcpd_leases_stats_scrapes_total - Total number of scrapes
  dhcpd_leases_stats_scrape_errors_total - Total number of scrapes errors
  dhcpd_leases_stats_last_scrape_error - Whether the last scrape of stats resulted in an error (1 for error, 0 for success).
  dhcpd_leases_stats_last_scrape_timestamp - Number of seconds since 1970 since last scrape of stat metrics.
Leases
  dhcpd_leases_active_client - The number of leases in dhcpd.leases that have not yet expired
  dhcpd_leases_stats_last_scrape_duration_seconds - Number of seconds since 1970 since last scrape of stat metrics.
  dhcpd_leases_active_scrapes_total - Total number of scrapes
  dhcpd_leases_active_scrape_errors_total - Total number of scrapes errors
  dhcpd_leases_active_last_scrape_error - Whether the last scrape resulted in an error (1 for error, 0 for success).
  dhcpd_leases_active_last_scrape_timestamp - Number of seconds since 1970 since last scrape.
```

Lastly, the tests still pass (run from my fork, which didn't change the go.mod module name):
```
$ scripts/test.sh
Building testing binary and running tests...
Running tests...
PASS
ok      github.com/DRuggeri/dhcpd_leases_exporter       0.067s
```